### PR TITLE
Change "scale" type from "number" to "string"

### DIFF
--- a/datapackage.json
+++ b/datapackage.json
@@ -39,7 +39,7 @@
           },
           {
             "name": "scale",
-            "type": "number",
+            "type": "string",
             "description": ""
           }
         ]


### PR DESCRIPTION
It contains values "Millions", "Billions" etc so the type should be "string".